### PR TITLE
Bump dlist upper bound to 0.9

### DIFF
--- a/unsequential.cabal
+++ b/unsequential.cabal
@@ -47,7 +47,7 @@ library
   exposed-modules:
     Unsequential
   build-depends:
-    dlist >= 0.7 && < 0.8,
+    dlist >= 0.7 && < 0.9,
     -- 
     transformers >= 0.4 && < 0.6,
     base-prelude < 2,


### PR DESCRIPTION
I just released [`dlist-0.8`](https://github.com/spl/dlist/releases/tag/v0.8). I didn't test this change to `unsequential`, but I don't think it will be break anything.
